### PR TITLE
Rearrange Windows setup instructions to be more intuitive

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -52,8 +52,25 @@
 
 <div class="row-fluid">
   <div class="span6">
+    <h4>Python</h4>
+    <ul>
+      <li>
+        Download and install  <a href="http://continuum.io/anacondace.html">Anaconda CE</a>.
+      </li>
+      <li>
+        Use all of the defaults for installation
+        <em>except</em>
+        make sure to check <strong>Make Anaconda the default Python</strong>.
+      </li>
+    </ul>
+    <h4>Git Bash</h4>
+    <p>
+      Install Git for Windows by download and running
+      <a href="https://msysgit.googlecode.com/files/Git-1.8.4-preview20130916.exe">the installer</a>.
+      This will provide you with both Git and Bash in the Git Bash program.
+    </p>
     <h4>Software Carpentry Installer</h4>
-    <p>For an all-in-one installer:</p>
+    <p>After installing Python and Git Bash:</p>
     <ul>
       <li>
         Download the <a href="https://raw.github.com/swcarpentry/bc/master/setup/swc-windows-installer.py">installer</a>.
@@ -66,6 +83,8 @@
         Double click on the file to run it.
       </li>
     </ul>
+  </div>
+  <div class="span6">
     <h4>Editor</h4>
     <p>
       <a href="http://notepad-plus-plus.org/">Notepad++</a> is a
@@ -75,25 +94,6 @@
       (or have other tools like Git launch it for you).
       Please ask your instructor to help you do this.
     </p>
-    <h4>Git Bash</h4>
-    <p>
-      Install Git for Windows by download and running
-      <a href="https://msysgit.googlecode.com/files/Git-1.8.4-preview20130916.exe">the installer</a>.
-      This will provide you with both Git and Bash in the Git Bash program.
-    </p>
-  </div>
-  <div class="span6">
-    <h4>Python</h4>
-    <ul>
-      <li>
-        Download and install  <a href="http://continuum.io/anacondace.html">Anaconda CE</a>.
-      </li>
-      <li>
-        Use all of the defaults for installation
-        <em>except</em>
-        make sure to check <strong>Make Anaconda the default Python</strong>.
-      </li>
-    </ul>
     <h4>SQLite</h4>
     <p>
       Download the <a href="http://files.software-carpentry.org/sqlite3.exe">sqlite3 program</a>


### PR DESCRIPTION
The current order risked students running the SWC installer
before installing either Python or GitBash (one of which is a
dependency depending on the installer).

The instructions also risked it sounding like it would install
everything instead of just adding a few extra pieces.
