### PR TITLE
Indicate that SWC Windows installer needs an internet connection

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -70,6 +70,7 @@
       This will provide you with both Git and Bash in the Git Bash program.
     </p>
     <h4>Software Carpentry Installer</h4>
+    <p>This installer requires an active internet connection</p>
     <p>After installing Python and Git Bash:</p>
     <ul>
       <li>


### PR DESCRIPTION
Turns out (after an hour of email debugging) that there's an edge case where a
user downloads our installer, copies it onto a usb key, puts in on a computer that
doesn't have an internet connection, and tries to run it.
